### PR TITLE
🧪 [testing improvement] Add error handling test for recordExerciseWithTimezone

### DIFF
--- a/src/services/__tests__/recordService.test.ts
+++ b/src/services/__tests__/recordService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import localforage from 'localforage'
 import {
   migrateRecordToTimezoneAware,
   migrateRecordsToTimezoneAware,
@@ -119,6 +120,16 @@ describe('RecordService Migration Functions', () => {
   })
 })
 
+// Mock localforage
+vi.mock('localforage', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    iterate: vi.fn(),
+    config: vi.fn()
+  }
+}))
+
 // Mock getAllRecords function
 vi.mock('../recordService', async () => {
   const actual = await vi.importActual('../recordService')
@@ -151,6 +162,15 @@ describe('Timezone-Aware Record Functions', () => {
 
       // This test verifies the function accepts custom date parameter
       await expect(recordExerciseWithTimezone('second', customDate)).resolves.toBeUndefined()
+    })
+
+    it('should throw error when storage fails', async () => {
+      // Mock localforage.setItem to throw an error
+      vi.mocked(localforage.setItem).mockRejectedValue(new Error('Storage error'))
+
+      await expect(recordExerciseWithTimezone('first'))
+        .rejects
+        .toThrow('Failed to record exercise with timezone information')
     })
   })
 


### PR DESCRIPTION
🎯 **What:** Added a unit test for error handling in `recordExerciseWithTimezone`.
📊 **Coverage:** The new test case mocks `localforage.setItem` to throw an error and asserts that the function re-throws it with the message 'Failed to record exercise with timezone information'.
✨ **Result:** Improved test coverage for error paths in the record service, ensuring that storage failures are handled and reported correctly.

---
*PR created automatically by Jules for task [17842524715260215010](https://jules.google.com/task/17842524715260215010) started by @kurousa*