### PR TITLE
🔒 Fix sensitive activity data exposure in console logs

### DIFF
--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -78,10 +78,6 @@ export async function recordExerciseWithTimezone(
 
     // 保存
     await localforage.setItem(localDateString, existingRecords)
-
-    console.log(
-      `タイムゾーン対応記録を保存しました: ${localDateString} - ${type} (${timezoneInfo.timezone})`,
-    )
   } catch (error) {
     console.error('タイムゾーン対応記録の保存に失敗しました:', error)
     throw new Error('Failed to record exercise with timezone information')

--- a/src/views/ExercisesView.vue
+++ b/src/views/ExercisesView.vue
@@ -137,8 +137,6 @@ export default defineComponent({
         setTimeout(() => {
           showCompletionPopup.value = false
         }, 2000) // 2秒後にポップアップを非表示
-
-        console.log(`タイムゾーン対応記録が完了しました: ${selectedExerciseType.value}`)
       } catch (error) {
         // エラー時のユーザー通知
         console.error('記録の保存中にエラーが発生しました:', error)

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -143,7 +143,6 @@ const motivationalMessage = computed(() => {
 const loadRecords = async () => {
   try {
     allRecords.value = await getRecordsWithTimezoneConversion()
-    console.log('タイムゾーン対応記録がロードされました:', allRecords.value)
   } catch (error) {
     console.error('記録の読み込みに失敗しました:', error)
     allRecords.value = await getAllRecords()
@@ -198,7 +197,6 @@ const updateCalendarAttributes = () => {
       }
     })
     calendarAttributes.value = attributes
-    console.log(`カレンダー属性が更新されました (${currentTimezone}):`, calendarAttributes.value)
   } catch (error) {
     console.error('カレンダー属性の更新に失敗しました:', error)
     const recordedDates = allRecords.value.map((record) => record.date)
@@ -219,7 +217,6 @@ const updateCalendarAttributes = () => {
       }
     })
     calendarAttributes.value = fallbackAttributes
-    console.log('フォールバック方式でカレンダー属性を更新しました:', calendarAttributes.value)
   }
 }
 const handleTimezoneChange = async (newTimezone: string, oldTimezone: string) => {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the exposure of detailed activity data (exercise records, dates, types, and timezones) in the browser console. This affected `src/services/recordService.ts`, `src/views/ProfileView.vue`, and `src/views/ExercisesView.vue`.

⚠️ **Risk:** If left unfixed, this information could be viewed by anyone with access to the browser's developer tools. This exposes sensitive user habits and location-related data (timezones), which is a privacy risk and a violation of secure coding practices regarding the handling of user data in client-side logs.

🛡️ **Solution:** I have removed the `console.log` statements that were outputting this sensitive information. I ensured that `console.error` calls were preserved so that actual failures are still logged for debugging purposes, but successful operations no longer leak user data. Verified the fix by reviewing the code and conducting a codebase-wide search for similar patterns.

---
*PR created automatically by Jules for task [2698375920460903864](https://jules.google.com/task/2698375920460903864) started by @kurousa*