### PR TITLE
🧹 [Code Health] Remove commented-out unused variables in YoutubePlayer

### DIFF
--- a/src/components/YoutubePlayer.vue
+++ b/src/components/YoutubePlayer.vue
@@ -6,10 +6,6 @@ import { YoutubeIframe } from '@vue-youtube/component'
 const props = defineProps<{
   videoId: string
 }>()
-
-// width と height はテンプレートに固定値として直接記述
-// const width = '800'; // setup スクリプト内では不要
-// const height = '450'; // setup スクリプト内では不要
 </script>
 
 <template>


### PR DESCRIPTION
🎯 **What:** Removed commented-out, unused `width` and `height` variables from the script setup block in `src/components/YoutubePlayer.vue`.
💡 **Why:** These commented-out variables represent dead code. Their associated comment clearly states they are unnecessary in the setup script, as width and height are directly provided to the component template as fixed attributes. Removing dead code improves code maintainability and readability by reducing clutter.
✅ **Verification:** Ran `pnpm run format` and `pnpm run test:unit`. No new issues were introduced by this change. Checked git status to make sure only `src/components/YoutubePlayer.vue` was modified.
✨ **Result:** A cleaner `YoutubePlayer.vue` component script with no unnecessary dead code, making it easier for developers to read and understand.

---
*PR created automatically by Jules for task [3018337674179296340](https://jules.google.com/task/3018337674179296340) started by @kurousa*