### PR TITLE
🧹 remove unused import ref in useNotifications test

### DIFF
--- a/src/composables/__tests__/useNotifications.test.ts
+++ b/src/composables/__tests__/useNotifications.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useNotifications } from '../useNotifications'
 import * as notificationService from '@/services/notificationService'
-import { ref, nextTick } from 'vue'
+import { nextTick } from 'vue'
 
 // Mock notificationService
 vi.mock('@/services/notificationService', () => ({


### PR DESCRIPTION
🎯 **What:** Removed the unused `ref` function import from `vue` in `src/composables/__tests__/useNotifications.test.ts`.
💡 **Why:** Improves code health and maintainability by cleaning up dead code.
✅ **Verification:** Manually verified that `ref` is no longer used in the file and that the necessary `nextTick` import remains.
✨ **Result:** A cleaner and more readable test file.

---
*PR created automatically by Jules for task [2045033386254089913](https://jules.google.com/task/2045033386254089913) started by @kurousa*