### PR TITLE
🧪 Add tests for useToastNotifications composable

### DIFF
--- a/src/composables/__tests__/useToastNotifications.test.ts
+++ b/src/composables/__tests__/useToastNotifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { useToastNotifications } from '../useNotifications'
+import { useToastNotifications, _resetToastState } from '../useNotifications'
 
 describe('useToastNotifications', () => {
   beforeEach(() => {
@@ -7,12 +7,7 @@ describe('useToastNotifications', () => {
   })
 
   afterEach(() => {
-    const { notifications, removeToast } = useToastNotifications()
-    // Clear all notifications after each test to ensure isolation
-    // We use a copy of the array because removeToast modifies the original
-    const currentNotifications = [...notifications.value]
-    currentNotifications.forEach((n) => removeToast(n.id))
-
+    _resetToastState()
     vi.restoreAllMocks()
     vi.useRealTimers()
   })
@@ -47,14 +42,14 @@ describe('useToastNotifications', () => {
     })
   })
 
-  it('should assign unique incremental IDs', () => {
+  it('should assign unique incremental IDs starting from 1', () => {
     const { addToast, notifications } = useToastNotifications()
     addToast('Message 1')
     addToast('Message 2')
 
     expect(notifications.value).toHaveLength(2)
-    expect(notifications.value[0].id).not.toBe(notifications.value[1].id)
-    expect(notifications.value[1].id).toBe(notifications.value[0].id + 1)
+    expect(notifications.value[0].id).toBe(1)
+    expect(notifications.value[1].id).toBe(2)
   })
 
   it('should remove a toast manually', () => {

--- a/src/composables/__tests__/useToastNotifications.test.ts
+++ b/src/composables/__tests__/useToastNotifications.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useToastNotifications } from '../useNotifications'
+
+describe('useToastNotifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    const { notifications, removeToast } = useToastNotifications()
+    // Clear all notifications after each test to ensure isolation
+    // We use a copy of the array because removeToast modifies the original
+    const currentNotifications = [...notifications.value]
+    currentNotifications.forEach((n) => removeToast(n.id))
+
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('should initialize with no notifications', () => {
+    const { notifications } = useToastNotifications()
+    expect(notifications.value).toEqual([])
+  })
+
+  it('should add a toast with default values', () => {
+    const { addToast, notifications } = useToastNotifications()
+    addToast('Test Message')
+
+    expect(notifications.value).toHaveLength(1)
+    expect(notifications.value[0]).toMatchObject({
+      message: 'Test Message',
+      type: 'info',
+      duration: 5000,
+    })
+    expect(notifications.value[0].id).toBeDefined()
+  })
+
+  it('should add a toast with custom values', () => {
+    const { addToast, notifications } = useToastNotifications()
+    addToast('Error Message', 'error', 2000)
+
+    expect(notifications.value).toHaveLength(1)
+    expect(notifications.value[0]).toMatchObject({
+      message: 'Error Message',
+      type: 'error',
+      duration: 2000,
+    })
+  })
+
+  it('should assign unique incremental IDs', () => {
+    const { addToast, notifications } = useToastNotifications()
+    addToast('Message 1')
+    addToast('Message 2')
+
+    expect(notifications.value).toHaveLength(2)
+    expect(notifications.value[0].id).not.toBe(notifications.value[1].id)
+    expect(notifications.value[1].id).toBe(notifications.value[0].id + 1)
+  })
+
+  it('should remove a toast manually', () => {
+    const { addToast, removeToast, notifications } = useToastNotifications()
+    addToast('To be removed')
+    const id = notifications.value[0].id
+
+    removeToast(id)
+    expect(notifications.value).toHaveLength(0)
+  })
+
+  it('should remove a toast automatically after duration', () => {
+    const { addToast, notifications } = useToastNotifications()
+    addToast('Auto remove', 'info', 1000)
+
+    expect(notifications.value).toHaveLength(1)
+
+    vi.advanceTimersByTime(1000)
+    expect(notifications.value).toHaveLength(0)
+  })
+
+  it('should not remove a toast automatically if duration is 0', () => {
+    const { addToast, notifications } = useToastNotifications()
+    addToast('Persistent', 'info', 0)
+
+    expect(notifications.value).toHaveLength(1)
+
+    vi.advanceTimersByTime(10000)
+    expect(notifications.value).toHaveLength(1)
+  })
+
+  it('should clear timeout when toast is removed manually before auto-removal', () => {
+    const { addToast, removeToast, notifications } = useToastNotifications()
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+
+    addToast('Manual then auto', 'info', 5000)
+    const id = notifications.value[0].id
+
+    removeToast(id)
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+
+    clearTimeoutSpy.mockRestore()
+  })
+
+  it('should do nothing when removing a non-existent toast id', () => {
+    const { addToast, removeToast, notifications } = useToastNotifications()
+    addToast('Exists')
+
+    removeToast(99999) // Non-existent ID
+    expect(notifications.value).toHaveLength(1)
+  })
+})

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -15,6 +15,18 @@ const toastTimeouts = new Map<number, ReturnType<typeof setTimeout>>()
 let nextId = 1
 
 // --- Composable for Toast Notifications ---
+
+/**
+ * Resets the toast notification state.
+ * This is intended for testing purposes only to ensure test isolation.
+ */
+export function _resetToastState() {
+  toastNotifications.value = []
+  toastTimeouts.forEach((timeoutId) => clearTimeout(timeoutId))
+  toastTimeouts.clear()
+  nextId = 1
+}
+
 export function useToastNotifications() {
   const addToast = (message: string, type: ToastNotification['type'] = 'info', duration = 5000) => {
     const id = nextId++


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `useToastNotifications` composable in `src/composables/useNotifications.ts`.

📊 **Coverage:**
- Initialization of notification state.
- `addToast` with default and custom values (message, type, duration).
- Generation of unique incremental IDs for consecutive notifications.
- `removeToast` functionality for manual dismissal.
- Auto-removal logic verified using `vi.useFakeTimers()`.
- Persistence of notifications when duration is set to 0.
- Proper cleanup of timeouts when a notification is manually dismissed before auto-expiry.
- Handling of non-existent notification IDs.

✨ **Result:** Significantly improved the test coverage and reliability of the global toast notification system. These tests ensure that notification state changes are predictable and that resources (timeouts) are correctly managed to prevent leaks.

---
*PR created automatically by Jules for task [5005241090690350896](https://jules.google.com/task/5005241090690350896) started by @kurousa*