### PR TITLE
🔒 Fix raw error exposure in UI notifications

### DIFF
--- a/src/services/__tests__/timezoneErrorHandler.test.ts
+++ b/src/services/__tests__/timezoneErrorHandler.test.ts
@@ -331,6 +331,21 @@ describe('TimezoneErrorHandler', () => {
 
       expect(mockCallback).toHaveBeenCalledWith(TIMEZONE_USER_MESSAGES.CONVERSION_ERROR, 'error')
     })
+
+    it('未知のエラータイプの場合にジェネリックメッセージを返す', () => {
+      const mockCallback = vi.fn()
+      TimezoneErrorHandler.registerNotificationCallback(mockCallback)
+
+      const error = {
+        type: 'unknown_type' as any,
+        message: '秘密の情報',
+        fallbackAction: 'なし',
+      }
+
+      TimezoneErrorHandler.handleError(error)
+
+      expect(mockCallback).toHaveBeenCalledWith(TIMEZONE_USER_MESSAGES.GENERIC_ERROR, 'error')
+    })
   })
 
   describe('通知レベル判定', () => {

--- a/src/services/timezoneService.ts
+++ b/src/services/timezoneService.ts
@@ -213,7 +213,7 @@ export class TimezoneErrorHandler {
       case 'conversion_error':
         return TIMEZONE_USER_MESSAGES.CONVERSION_ERROR
       default:
-        return `タイムゾーン処理でエラーが発生しました: ${error.message}`
+        return TIMEZONE_USER_MESSAGES.GENERIC_ERROR
     }
   }
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -49,6 +49,7 @@ export const TIMEZONE_USER_MESSAGES = {
   DETECTION_FAILED: 'タイムゾーンの自動検出ができませんでした。UTC時刻で表示されます。',
   INVALID_TIMEZONE: 'タイムゾーン設定に問題があります。標準時刻で表示されます。',
   CONVERSION_ERROR: '時刻の変換処理でエラーが発生しました。表示が正しくない可能性があります。',
+  GENERIC_ERROR: 'システムエラーが発生しました。',
 } as const
 
 /**

--- a/src/views/ExercisesView.vue
+++ b/src/views/ExercisesView.vue
@@ -147,7 +147,7 @@ export default defineComponent({
         }, 3000) // 3秒後にエラーポップアップを非表示
 
         // TimezoneErrorHandlerを使用してエラーログを出力
-        TimezoneErrorHandler.showUserNotification(`記録保存エラー: ${error}`)
+        TimezoneErrorHandler.showUserNotification('記録の保存中にエラーが発生しました。')
       }
     }
 

--- a/src/views/__tests__/ExercisesView.test.ts
+++ b/src/views/__tests__/ExercisesView.test.ts
@@ -145,7 +145,7 @@ describe('ExercisesView', () => {
     await wrapper.vm.$nextTick()
 
     expect(TimezoneErrorHandler.showUserNotification).toHaveBeenCalledWith(
-      expect.stringContaining('記録保存エラー'),
+      '記録の保存中にエラーが発生しました。',
     )
   })
 })

--- a/src/views/__tests__/ExercisesView.test.ts
+++ b/src/views/__tests__/ExercisesView.test.ts
@@ -145,7 +145,7 @@ describe('ExercisesView', () => {
     await wrapper.vm.$nextTick()
 
     expect(TimezoneErrorHandler.showUserNotification).toHaveBeenCalledWith(
-      '記録の保存中にエラーが発生しました。',
+      '記録の保存に失敗しました。もう一度お試しください。',
     )
   })
 })


### PR DESCRIPTION
🎯 **What:** Fixed raw error exposure in user-facing notifications in `ExercisesView.vue` and `timezoneService.ts`.

⚠️ **Risk:** Directly exposing error objects or detailed error messages to users can leak sensitive system information, such as stack traces or internal logic, which could be exploited by an attacker to gain insights into the application's internals.

🛡️ **Solution:** Replaced raw error interpolation with generic, user-friendly error messages. Added a `GENERIC_ERROR` constant to `TIMEZONE_USER_MESSAGES` for consistent error handling and updated `TimezoneErrorHandler.formatUserMessage` to use it as a fallback. This ensures that even unexpected error types do not leak raw exception details to the frontend.

---
*PR created automatically by Jules for task [13367136929770827360](https://jules.google.com/task/13367136929770827360) started by @kurousa*