### PR TITLE
🔒 Consistent generic error messages in ExercisesView

### DIFF
--- a/src/services/__tests__/timezoneErrorHandler.test.ts
+++ b/src/services/__tests__/timezoneErrorHandler.test.ts
@@ -331,6 +331,21 @@ describe('TimezoneErrorHandler', () => {
 
       expect(mockCallback).toHaveBeenCalledWith(TIMEZONE_USER_MESSAGES.CONVERSION_ERROR, 'error')
     })
+
+    it('未知のエラータイプの場合にジェネリックメッセージを返す', () => {
+      const mockCallback = vi.fn()
+      TimezoneErrorHandler.registerNotificationCallback(mockCallback)
+
+      const error = {
+        type: 'unknown_type' as any,
+        message: '秘密の情報',
+        fallbackAction: 'なし',
+      }
+
+      TimezoneErrorHandler.handleError(error)
+
+      expect(mockCallback).toHaveBeenCalledWith(TIMEZONE_USER_MESSAGES.GENERIC_ERROR, 'error')
+    })
   })
 
   describe('通知レベル判定', () => {

--- a/src/services/timezoneService.ts
+++ b/src/services/timezoneService.ts
@@ -213,7 +213,7 @@ export class TimezoneErrorHandler {
       case 'conversion_error':
         return TIMEZONE_USER_MESSAGES.CONVERSION_ERROR
       default:
-        return `タイムゾーン処理でエラーが発生しました: ${error.message}`
+        return TIMEZONE_USER_MESSAGES.GENERIC_ERROR
     }
   }
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -49,6 +49,7 @@ export const TIMEZONE_USER_MESSAGES = {
   DETECTION_FAILED: 'タイムゾーンの自動検出ができませんでした。UTC時刻で表示されます。',
   INVALID_TIMEZONE: 'タイムゾーン設定に問題があります。標準時刻で表示されます。',
   CONVERSION_ERROR: '時刻の変換処理でエラーが発生しました。表示が正しくない可能性があります。',
+  GENERIC_ERROR: 'システムエラーが発生しました。',
 } as const
 
 /**

--- a/src/views/ExercisesView.vue
+++ b/src/views/ExercisesView.vue
@@ -147,7 +147,7 @@ export default defineComponent({
         }, 3000) // 3秒後にエラーポップアップを非表示
 
         // TimezoneErrorHandlerを使用してエラーログを出力
-        TimezoneErrorHandler.showUserNotification(`記録保存エラー: ${error}`)
+        TimezoneErrorHandler.showUserNotification(errorMessage.value)
       }
     }
 

--- a/src/views/__tests__/ExercisesView.test.ts
+++ b/src/views/__tests__/ExercisesView.test.ts
@@ -145,7 +145,7 @@ describe('ExercisesView', () => {
     await wrapper.vm.$nextTick()
 
     expect(TimezoneErrorHandler.showUserNotification).toHaveBeenCalledWith(
-      expect.stringContaining('記録保存エラー'),
+      '記録の保存に失敗しました。もう一度お試しください。',
     )
   })
 })


### PR DESCRIPTION
🎯 **What:** Improved the security fix in `ExercisesView.vue` by using the established `errorMessage.value` for the `showUserNotification` call.

⚠️ **Risk:** The previous fix introduced a minor inconsistency in user-facing error messages, which could be confusing.

🛡️ **Solution:** By using `errorMessage.value`, we maintain a single, secure, user-friendly message for both the popup and the notification system, fulfilling both security and UX requirements.

---
*PR created automatically by Jules for task [13367136929770827360](https://jules.google.com/task/13367136929770827360) started by @kurousa*