### PR TITLE
🔒 [security fix] Fix missing try/catch around localStorage.setItem

### DIFF
--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useNotifications } from '../useNotifications'
+import { useNotifications, _resetToastState } from '../useNotifications'
 import * as notificationService from '@/services/notificationService'
 import { nextTick } from 'vue'
 

--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useNotifications } from '../useNotifications'
+import * as notificationService from '@/services/notificationService'
+import { nextTick } from 'vue'
+
+// Mock notificationService
+vi.mock('@/services/notificationService', () => ({
+  requestNotificationPermission: vi.fn(),
+  scheduleNotification: vi.fn(),
+  cancelNotification: vi.fn(),
+}))
+
+describe('useNotifications - Storage Errors', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('should not crash when localStorage.setItem throws an error', async () => {
+    // Mock setItem to throw an error
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+
+    // Mock console.error to avoid polluting test output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { isEnabled } = useNotifications()
+
+    // Trigger a change that calls saveSettings
+    isEnabled.value = true
+    await nextTick()
+
+    // It should have called setItem and caught the error
+    expect(setItemSpy).toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error saving notification settings to localStorage:',
+      expect.any(Error)
+    )
+
+    // Verify it didn't crash and the app continues to function
+    expect(isEnabled.value).toBe(true)
+
+    consoleSpy.mockRestore()
+    setItemSpy.mockRestore()
+  })
+})

--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -15,6 +15,7 @@ describe('useNotifications - Storage Errors', () => {
     localStorage.clear()
     vi.clearAllMocks()
     vi.restoreAllMocks()
+    _resetToastState()
   })
 
   it('should not crash when localStorage.setItem throws an error', async () => {

--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -5,7 +5,7 @@ import { nextTick } from 'vue'
 
 // Mock notificationService
 vi.mock('@/services/notificationService', () => ({
-  requestNotificationPermission: vi.fn(),
+  requestNotificationPermission: vi.fn().mockResolvedValue('granted'),
   scheduleNotification: vi.fn(),
   cancelNotification: vi.fn(),
 }))

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -91,7 +91,11 @@ export function useNotifications() {
       isEnabled: isEnabled.value,
       time: notificationTime.value,
     }
-    localStorage.setItem(NOTIFICATION_SETTINGS_KEY, JSON.stringify(settings))
+    try {
+      localStorage.setItem(NOTIFICATION_SETTINGS_KEY, JSON.stringify(settings))
+    } catch (error) {
+      console.error('Error saving notification settings to localStorage:', error)
+    }
   }
 
   // Load initial settings


### PR DESCRIPTION
🎯 **What:** Added a try/catch block around `localStorage.setItem` in the `saveSettings` function of `useNotifications.ts`.

⚠️ **Risk:** Without this fix, the application could crash if `localStorage` is unavailable, full (QuotaExceededError), or if the browser blocks access to storage. This leads to a poor user experience and potential denial of service for the application's notification features.

🛡️ **Solution:** Wrapped the `setItem` call in a `try/catch` block and added a unit test `src/composables/__tests__/useNotifications.storage.test.ts` to verify that the application handles storage errors gracefully by logging them to the console instead of crashing.

---
*PR created automatically by Jules for task [401781126511365230](https://jules.google.com/task/401781126511365230) started by @kurousa*