### PR TITLE
🧹 Remove dead commented-out code in ProfileView.vue

### DIFF
--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -156,7 +156,6 @@ const updateCalendarAttributes = () => {
           const exerciseType = record.type === 'first' ? 'ラジオ体操第一' : 'ラジオ体操第二'
           let timeInfo = ''
           if (record.timezone) {
-            // // const utcTime = new Date(record.timestamp)
             const timeString = new Date(record.timestamp).toLocaleTimeString('ja-JP', {
               hour: '2-digit',
               minute: '2-digit',
@@ -165,7 +164,6 @@ const updateCalendarAttributes = () => {
             const timezoneAbbr = record.timezone.split('/').pop() || record.timezone
             timeInfo = ` (${timeString} ${timezoneAbbr})`
           } else if (record.timestamp) {
-            // // const utcTime = new Date(record.timestamp)
             const localTime = TimezoneService.convertUTCToLocal(record.timestamp, currentTimezone)
             const timeString = localTime.toLocaleTimeString('ja-JP', {
               hour: '2-digit',


### PR DESCRIPTION
🎯 **What:**
Removed two instances of the commented-out line `// // const utcTime = new Date(record.timestamp)` within the `updateCalendarAttributes` function in `src/views/ProfileView.vue`.

💡 **Why:**
This was dead code that provided no value and cluttered the logic for formatting record details in the calendar view. Removing it improves maintainability and readability.

✅ **Verification:**
- Manually verified the file content after modification using `cat`.
- Requested and received a positive code review.
- Local unit test execution was attempted but blocked by persistent environment timeouts/installation issues (handled as per project guidelines).

✨ **Result:**
Cleaner and more readable source code in `ProfileView.vue`.

---
*PR created automatically by Jules for task [16587181758558020992](https://jules.google.com/task/16587181758558020992) started by @kurousa*