### PR TITLE
🧪 Add error path test for registerServiceWorker

### DIFF
--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -40,6 +40,20 @@ describe('notificationService', () => {
     expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js')
   })
 
+  it('should log an error if service worker registration fails', async () => {
+    const error = new Error('Registration failed')
+    vi.mocked(navigator.serviceWorker.register).mockRejectedValueOnce(error)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await registerServiceWorker()
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Service Worker registration failed from service:',
+      error
+    )
+    consoleSpy.mockRestore()
+  })
+
   it('should call Notification.requestPermission', async () => {
     const permission = await requestNotificationPermission()
     expect(Notification.requestPermission).toHaveBeenCalled()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing error path test for `registerServiceWorker` in `src/services/notificationService.ts`.
📊 **Coverage:** Added a test scenario that mocks a rejection from `navigator.serviceWorker.register` and asserts that `console.error` is called with the expected message and error object.
✨ **Result:** Increased the reliability and coverage of the notification service tests by ensuring that registration failures are properly tracked via logging.

---
*PR created automatically by Jules for task [2900012775673266625](https://jules.google.com/task/2900012775673266625) started by @kurousa*