### PR TITLE
🧪 [Testing Improvement: Add missing test for unsupported serviceWorker in registerServiceWorker]

### DIFF
--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -40,11 +40,8 @@ describe('useNotifications - Storage Errors', () => {
     isEnabled.value = true
     await nextTick()
 
-    // We also need to wait for any promises inside watch to resolve.
-    // The watch calls async function notificationService.requestNotificationPermission().
-    // We can yield the event loop to ensure they finish.
-    // Use a longer timeout or flushPromises if possible
-    await new Promise(resolve => setTimeout(resolve, 50))
+    // Wait for the async watcher to complete its internal promises
+    await nextTick()
 
     // It should have called setItem and caught the error
     expect(setItemSpy).toHaveBeenCalled()

--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -27,11 +27,24 @@ describe('useNotifications - Storage Errors', () => {
     // Mock console.error to avoid polluting test output
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
+    // Ensure the mock returns 'granted'
+    vi.mocked(notificationService.requestNotificationPermission).mockResolvedValue('granted')
+
     const { isEnabled } = useNotifications()
 
     // Trigger a change that calls saveSettings
+    // We need to bypass the watch conditional 'oldValue === undefined'
+    // To do this, we can set it to false first, wait for tick, then to true
+    isEnabled.value = false
+    await nextTick()
     isEnabled.value = true
     await nextTick()
+
+    // We also need to wait for any promises inside watch to resolve.
+    // The watch calls async function notificationService.requestNotificationPermission().
+    // We can yield the event loop to ensure they finish.
+    // Use a longer timeout or flushPromises if possible
+    await new Promise(resolve => setTimeout(resolve, 50))
 
     // It should have called setItem and caught the error
     expect(setItemSpy).toHaveBeenCalled()

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -54,6 +54,16 @@ describe('notificationService', () => {
     consoleSpy.mockRestore()
   })
 
+  it('should not throw if serviceWorker is not supported in navigator', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {},
+      writable: true,
+    })
+
+    await expect(registerServiceWorker()).resolves.toBeUndefined()
+  })
+
+
   it('should call Notification.requestPermission', async () => {
     const permission = await requestNotificationPermission()
     expect(Notification.requestPermission).toHaveBeenCalled()


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify that `registerServiceWorker` safely handles scenarios where `serviceWorker` is not available in the `navigator` object, and fixed a flaky test issue in `useNotifications.storage.test.ts`.

📊 **Coverage:** Ensures `registerServiceWorker` resolves without throwing errors in environments that do not support Service Workers, filling a gap in `notificationService.ts` coverage.

✨ **Result:** Improves test coverage for `notificationService.ts`, increasing robustness by asserting safe early exit on missing browser features. Evaluated and confirmed against local test suite and CI equivalents.

---
*PR created automatically by Jules for task [4048866376345034590](https://jules.google.com/task/4048866376345034590) started by @kurousa*