### PR TITLE
🧹 [Extract useToastNotifications to separate file]

### DIFF
--- a/src/components/NotificationToast.vue
+++ b/src/components/NotificationToast.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { useToastNotifications } from '../composables/useNotifications'
+import { useToastNotifications } from '../composables/useToastNotifications'
 
 const { notifications, removeToast } = useToastNotifications()
 </script>

--- a/src/composables/__tests__/useNotifications.storage.test.ts
+++ b/src/composables/__tests__/useNotifications.storage.test.ts
@@ -1,6 +1,7 @@
 import * as notificationService from '@/services/notificationService'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useNotifications, _resetToastState } from '../useNotifications'
+import { useNotifications } from '../useNotifications'
+import { _resetToastState } from '../useToastNotifications'
 
 import { nextTick } from 'vue'
 
@@ -34,13 +35,13 @@ describe('useNotifications - Storage Errors', () => {
     const { notificationTime } = useNotifications()
     notificationTime.value = '09:00'
     await nextTick()
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     // It should have called setItem and caught the error
     expect(setItemSpy).toHaveBeenCalled()
     expect(consoleSpy).toHaveBeenCalledWith(
       'Error saving notification settings to localStorage:',
-      expect.any(Error)
+      expect.any(Error),
     )
 
     // Verify it didn't crash and the app continues to function

--- a/src/composables/__tests__/useToastNotifications.test.ts
+++ b/src/composables/__tests__/useToastNotifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { useToastNotifications, _resetToastState } from '../useNotifications'
+import { useToastNotifications, _resetToastState } from '../useToastNotifications'
 
 describe('useToastNotifications', () => {
   beforeEach(() => {

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -1,63 +1,11 @@
-import { ref, watch, readonly } from 'vue'
+import { ref, watch } from 'vue'
 import * as notificationService from '@/services/notificationService'
+import { useToastNotifications } from './useToastNotifications'
 
-// --- State for Toast Notifications (Global) ---
-interface ToastNotification {
-  id: number
-  message: string
-  type: 'info' | 'error' | 'warning'
-  duration: number
-}
-
-const toastNotifications = ref<ToastNotification[]>([])
-const toastTimeouts = new Map<number, ReturnType<typeof setTimeout>>()
-
-let nextId = 1
-
-// --- Composable for Toast Notifications ---
-
-/**
- * Resets the toast notification state.
- * This is intended for testing purposes only to ensure test isolation.
- */
-export function _resetToastState() {
-  toastNotifications.value = []
-  toastTimeouts.forEach((timeoutId) => clearTimeout(timeoutId))
-  toastTimeouts.clear()
-  nextId = 1
-}
-
-export function useToastNotifications() {
-  const addToast = (message: string, type: ToastNotification['type'] = 'info', duration = 5000) => {
-    const id = nextId++
-    toastNotifications.value.push({ id, message, type, duration })
-    if (duration > 0) {
-      const timeoutId = setTimeout(() => removeToast(id), duration)
-      toastTimeouts.set(id, timeoutId)
-    }
-  }
-
-  const removeToast = (id: number) => {
-    if (toastTimeouts.has(id)) {
-      clearTimeout(toastTimeouts.get(id)!)
-      toastTimeouts.delete(id)
-    }
-    const index = toastNotifications.value.findIndex((n) => n.id === id)
-    if (index > -1) {
-      toastNotifications.value.splice(index, 1)
-    }
-  }
-
-  return {
-    notifications: readonly(toastNotifications),
-    addToast,
-    removeToast,
-  }
-}
 // --- Composable for Push Notification Settings ---
 const NOTIFICATION_SETTINGS_KEY = 'radio-fit-app-notification-settings'
 
-interface NotificationSettings {
+export interface NotificationSettings {
   isEnabled: boolean
   time: string
 }

--- a/src/composables/useToastNotifications.ts
+++ b/src/composables/useToastNotifications.ts
@@ -1,0 +1,55 @@
+import { ref, readonly } from 'vue'
+
+// --- State for Toast Notifications (Global) ---
+export interface ToastNotification {
+  id: number
+  message: string
+  type: 'info' | 'error' | 'warning'
+  duration: number
+}
+
+const toastNotifications = ref<ToastNotification[]>([])
+const toastTimeouts = new Map<number, ReturnType<typeof setTimeout>>()
+
+let nextId = 1
+
+// --- Composable for Toast Notifications ---
+
+/**
+ * Resets the toast notification state.
+ * This is intended for testing purposes only to ensure test isolation.
+ */
+export function _resetToastState() {
+  toastNotifications.value = []
+  toastTimeouts.forEach((timeoutId) => clearTimeout(timeoutId))
+  toastTimeouts.clear()
+  nextId = 1
+}
+
+export function useToastNotifications() {
+  const addToast = (message: string, type: ToastNotification['type'] = 'info', duration = 5000) => {
+    const id = nextId++
+    toastNotifications.value.push({ id, message, type, duration })
+    if (duration > 0) {
+      const timeoutId = setTimeout(() => removeToast(id), duration)
+      toastTimeouts.set(id, timeoutId)
+    }
+  }
+
+  const removeToast = (id: number) => {
+    if (toastTimeouts.has(id)) {
+      clearTimeout(toastTimeouts.get(id)!)
+      toastTimeouts.delete(id)
+    }
+    const index = toastNotifications.value.findIndex((n) => n.id === id)
+    if (index > -1) {
+      toastNotifications.value.splice(index, 1)
+    }
+  }
+
+  return {
+    notifications: readonly(toastNotifications),
+    addToast,
+    removeToast,
+  }
+}


### PR DESCRIPTION
🎯 **What:** The `useNotifications.ts` file had a large scope by combining logic for toast notifications and generic push notification settings. This PR extracts the toast notification state and logic into a separate `useToastNotifications.ts` composable file.

💡 **Why:** Smaller, modular components/composables increase readability, maintainability, and reusability. It allows distinct logic paths (toast notifications vs. push notifications) to be tested and reasoned about independently.

✅ **Verification:** 
- `pnpm run test:unit` was run and all tests pass.
- Used `read_file` to verify extraction and import changes.
- `git diff` confirms exact extraction without breaking code.
- `pnpm run format && pnpm run lint` pass successfully.

✨ **Result:** Improved code health and separated concerns within composables.

---
*PR created automatically by Jules for task [15453172333507009925](https://jules.google.com/task/15453172333507009925) started by @kurousa*